### PR TITLE
Hierarchy improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,5 +68,8 @@ compass_session = ci.logon(username=..., password=...)
 hierarchy = ci.Hierarchy(compass_session)
 people = ci.People(compass_session)
 
+# Get all unique members from the in your hierarchy
+member_set = hierarchy.get_unique_members()
+
 
 ```

--- a/compass/hierarchy.py
+++ b/compass/hierarchy.py
@@ -43,7 +43,7 @@ class Hierarchy:
         """Constructor for Hierarchy."""
         self._scraper: HierarchyScraper = HierarchyScraper(session.s)
         self.validate: bool = validate
-        self.unit_level: schema.HierarchyLevel = session.hierarchy
+        self.session: Logon = session
 
     def get_unit_data(
         self,
@@ -78,7 +78,7 @@ class Hierarchy:
         elif id is not None and level is not None:
             data = schema.HierarchyLevel(id=_id, level=level)
         elif use_default:
-            data = self.unit_level
+            data = self.session.hierarchy  # as this is a property, it will update when roles change
         else:
             raise ValueError("No level data specified! unit_level, id and level, or use_default must be set!")
 

--- a/compass/hierarchy.py
+++ b/compass/hierarchy.py
@@ -78,6 +78,8 @@ class Hierarchy:
         else:
             raise ValueError("No level data specified! unit_level, id and level, or use_default must be set!")
 
+        logger.debug(f"found unit data: id: {unit_level.id}, level: {unit_level.level}")
+
         filename = Path(f"hierarchy-{unit_level.id}.json")
         # Attempt to see if the hierarchy has been fetched already and is on the local system
         with contextlib.suppress(FileNotFoundError):
@@ -189,6 +191,8 @@ class Hierarchy:
             unit_level = self.unit_level
         else:
             raise ValueError("No level data specified! unit_level, id and level, or use_default must be set!")
+
+        logger.debug(f"found unit data: id: {unit_level.id}, level: {unit_level.level}")
 
         # get tree of all units
         hierarchy_dict = self.get_hierarchy(unit_level)

--- a/compass/hierarchy.py
+++ b/compass/hierarchy.py
@@ -90,7 +90,7 @@ class Hierarchy:
     def get_hierarchy(
         self,
         unit_level: Optional[schema.HierarchyLevel] = None,
-        id: Optional[int] = None,
+        unit_id: Optional[int] = None,
         level: Optional[str] = None,
         use_default: bool = False,
     ) -> Union[dict, schema.UnitData]:
@@ -110,7 +110,7 @@ class Hierarchy:
                 When no unit data information has been provided
 
         """
-        unit_level = self.get_unit_data(unit_level, id, level, use_default)
+        unit_level = self.get_unit_data(unit_level, unit_id, level, use_default)
 
         filename = Path(f"hierarchy-{unit_level.id}.json")
         # Attempt to see if the hierarchy has been fetched already and is on the local system
@@ -192,7 +192,7 @@ class Hierarchy:
     def get_unique_members(
         self,
         unit_level: Optional[schema.HierarchyLevel] = None,
-        id: Optional[int] = None,
+        unit_id: Optional[int] = None,
         level: Optional[str] = None,
         use_default: bool = False,
     ) -> set[int]:
@@ -215,7 +215,7 @@ class Hierarchy:
                 When no unit data information has been provided
 
         """
-        unit_level = self.get_unit_data(unit_level, id, level, use_default)
+        unit_level = self.get_unit_data(unit_level, unit_id, level, use_default)
 
         # get tree of all units
         hierarchy_dict = self.get_hierarchy(unit_level)

--- a/compass/hierarchy.py
+++ b/compass/hierarchy.py
@@ -46,11 +46,11 @@ class Hierarchy:
         self.unit_level: schema.HierarchyLevel = session.hierarchy
 
     def get_unit_data(
-            self,
-            unit_level: Optional[schema.HierarchyLevel] = None,
-            _id: Optional[int] = None,
-            level: Optional[str] = None,
-            use_default: bool = False,
+        self,
+        unit_level: Optional[schema.HierarchyLevel] = None,
+        _id: Optional[int] = None,
+        level: Optional[str] = None,
+        use_default: bool = False,
     ) -> schema.HierarchyLevel:
         """Helper function to construct unit level data.
 

--- a/compass/logon.py
+++ b/compass/logon.py
@@ -6,6 +6,7 @@ import certifi
 from lxml import html
 import requests
 
+from compass import schemas
 from compass.errors import CompassAuthenticationError
 from compass.errors import CompassError
 from compass.interface_base import InterfaceBase
@@ -14,7 +15,6 @@ from compass.settings import Settings
 from compass.utility import cast
 from compass.utility import compass_restify
 from compass.utility import setup_tls_certs
-from compass import schemas
 
 TYPES_UNIT_LEVELS = Literal["Group", "District", "County", "Region", "Country", "Organisation"]
 

--- a/compass/logon.py
+++ b/compass/logon.py
@@ -1,6 +1,6 @@
 import datetime
 import time
-from typing import Optional
+from typing import Literal, Optional
 
 import certifi
 from lxml import html
@@ -14,6 +14,9 @@ from compass.settings import Settings
 from compass.utility import cast
 from compass.utility import compass_restify
 from compass.utility import setup_tls_certs
+from compass import schemas
+
+TYPES_UNIT_LEVELS = Literal["Group", "District", "County", "Region", "Country", "Organisation"]
 
 
 class Logon(InterfaceBase):
@@ -41,6 +44,27 @@ class Logon(InterfaceBase):
     @property
     def jk(self) -> int:
         return self.compass_dict["Master.User.JK"]  # ???? Key?
+
+    @property
+    def hierarchy(self) -> schemas.hierarchy.HierarchyLevel:
+        unit_number = self.compass_dict["Master.User.ON"]  # Organisation Number
+        unit_level = self.compass_dict["Master.User.LVL"]  # Level
+        level_map = {
+            "ORG": "Organisation",
+            # "ORST": "Organisation Sections",
+            "CNTR": "Country",
+            # "CNST": "Country Sections",
+            "REG": "Region",
+            # "RGST": "Regional Sections",
+            "CNTY": "County",  # Also Area/Scot Reg/Branch
+            # "CTST": "County Sections",  # Also Area/Scot Reg/Branch
+            "DIST": "District",
+            # "DTST": "District Sections",
+            "SGRP": "Group",
+            # "SGST": "Group Sections",
+        }
+
+        return schemas.hierarchy.HierarchyLevel(id=unit_number, level=level_map[unit_level])
 
     def _get(self, url: str, auth_header: bool = False, session: Optional[requests.Session] = None, **kwargs) -> requests.Response:
         """Override get method with custom auth_header logic."""

--- a/compass/schemas/hierarchy.py
+++ b/compass/schemas/hierarchy.py
@@ -36,8 +36,11 @@ class HierarchySection(HierarchyUnit):
     section_type: Optional[TYPES_SECTION]
 
 
-class UnitData(HierarchyBase):
+class HierarchyLevel(HierarchyBase):
     level: TYPES_UNIT_LEVELS
+
+
+class UnitData(HierarchyLevel):
     child: Optional[list[DescendantData]]  # NOTE: deliberate recursive/forward reference here!
     sections: list[HierarchySection]
 
@@ -57,7 +60,7 @@ class HierarchyMember(pydantic.BaseModel):
 
 
 class HierarchyUnitMembers(pydantic.BaseModel):
-    compass_id: int
+    compass_id: int  # TODO disambiguate this
     member: list[HierarchyMember]
 
 


### PR DESCRIPTION
Fixes #7 

Add Logon.hierarchy property, returning user's current role's hierarchy details.

Refactored Hierarchy methods to use new HierarchyLevel model and, by default, the hierarchy data from Logon.

TODO: 
- passing in custom level id and level type now requires pre-constructing the HierarchyLevel model - how to enable manual intervention
- the hierarchy data is stored in the Hierarchy object on initialisation, so if the user changes his role the hierarchy data will not update