### PR TITLE
🔖 RLS: v0.4.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # setuptools metadata
 [metadata]
 name = compass-interface-core
-version = 0.3.0
+version = 0.4.0
 # version = attr: src.VERSION
 description = The unofficial API to the TSA Compass membership database
 long_description = file: README.md


### PR DESCRIPTION
Release - 0.4.0

this is a 0.Y.0 release as we have a few API changes

- Reports changes have created a `compass.reports.Reports` class
- Most functionality has been moved under `compass.core` and re-exposed directly under `compass` where needed
- Moved `compass.util` to the compass-interface main project