### PR TITLE
🐛 log data rather than unit_level

### DIFF
--- a/compass/core/hierarchy.py
+++ b/compass/core/hierarchy.py
@@ -82,7 +82,7 @@ class Hierarchy:
         else:
             raise ValueError("No level data specified! unit_level, id and level, or use_default must be set!")
 
-        logger.debug(f"found unit data: id: {unit_level.id}, level: {unit_level.level}")
+        logger.debug(f"found unit data: id: {data.id}, level: {data.level}")
 
         return data
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # setuptools metadata
 [metadata]
 name = compass-interface-core
-version = 0.4.2
+version = 0.4.3
 # version = attr: src.VERSION
 description = The unofficial API to the TSA Compass membership database
 long_description = file: README.md


### PR DESCRIPTION
🐛 log data rather than unit_level where unit_level may be None in the hierarchy.py

Small PR for a small bug! 

In the hierarchy.py, under `get_unit_data` the logger was attempting to log from a potentially `None` variable and caused issues when using `use_default`.