### PR TITLE
Login refactor

### DIFF
--- a/compass/core/logon.py
+++ b/compass/core/logon.py
@@ -42,6 +42,7 @@ class Logon(InterfaceBase):
       c. Update data for authorisation headers for requests to Compass.
 
     """
+
     def __init__(self, credentials: tuple[str, str], role_to_use: str = None):
         """Constructor for Logon."""
         self._member_role_number = 0
@@ -209,8 +210,8 @@ class Logon(InterfaceBase):
 
         # Update current role properties
         self.current_role = self.roles_dict[self.mrn]
-        location = next((row[2].text_content().strip() for row in form.xpath(f"//tbody/tr") if int(row.get("data-pk")) == self.mrn), "")
-        logger.debug(f"Using Role: {self.current_role} ({location})")
+        location = next(row[2].text_content() for row in form.xpath(f"//tbody/tr") if int(row.get("data-pk")) == self.mrn)
+        logger.debug(f"Using Role: {self.current_role} ({location.strip()})")
 
         # Verify role number against test value
         if check_role_number is not None:

--- a/compass/core/logon.py
+++ b/compass/core/logon.py
@@ -211,7 +211,7 @@ class Logon(InterfaceBase):
 
         # Update current role properties
         self.current_role = self.roles_dict[self.mrn]
-        location = next(row[2].text_content() for row in form.xpath(f"//tbody/tr") if int(row.get("data-pk")) == self.mrn)
+        location = next(row[2].text_content() for row in form.xpath("//tbody/tr") if int(row.get("data-pk")) == self.mrn)
         logger.debug(f"Using Role: {self.current_role} ({location.strip()})")
 
         # Verify role number against test value

--- a/compass/core/logon.py
+++ b/compass/core/logon.py
@@ -1,6 +1,6 @@
 import datetime
 import time
-from typing import Literal, Optional
+from typing import Literal
 
 import certifi
 from lxml import html
@@ -21,6 +21,27 @@ TYPES_UNIT_LEVELS = Literal["Group", "District", "County", "Region", "Country", 
 
 
 class Logon(InterfaceBase):
+    """Create connection to Compass and authenticate. Holds session state.
+
+    Logon flow is:
+    1. Create a persistent state object (Session) to hold headers, cookies etc.
+      a. Check and verify that TLS certificates for Compass have been set up.
+      b. Get ASP.NET session cookie from Compass. (HTTP request #1)
+    2. Post login data to Compass. (HTTP request #2)
+    3. Get sample page from Compass. (HTTP request #3)
+    4. Verify login was successful
+      a. Create dict of compass internal variables, e.g. Master.User.CN (POST_CTRL).
+      b. Create dict of user's role title to internal role number
+      c. Update data for authorisation headers for requests to Compass.
+    IF Role title specified:
+    5. Post new role number to Compass (HTTP request #4)
+    6. Get sample page from Compass. (HTTP request #5)
+    7. Get currently active role number, and check this equals the requested role number.
+      a. Create dict of compass internal variables, e.g. Master.User.CN (POST_CTRL).
+      b. Create dict of user's role title to internal role number
+      c. Update data for authorisation headers for requests to Compass.
+
+    """
     def __init__(self, credentials: tuple[str, str], role_to_use: str = None):
         """Constructor for Logon."""
         self._member_role_number = 0

--- a/compass/core/logon.py
+++ b/compass/core/logon.py
@@ -18,6 +18,7 @@ from compass.core.utility import PeriodicTimer
 from compass.core.utility import setup_tls_certs
 
 TYPES_UNIT_LEVELS = Literal["Group", "District", "County", "Region", "Country", "Organisation"]
+TYPES_STO = Literal[None, "0", "5", "X"]
 
 
 class Logon(InterfaceBase):
@@ -130,7 +131,7 @@ class Logon(InterfaceBase):
 
     # Timeout code:
 
-    def _extend_session_timeout(self, sto: Literal[None, "0", "5", "X"] = "0"):
+    def _extend_session_timeout(self, sto: TYPES_STO = "0"):
         # Session time out. 4 values: None (normal), 0 (STO prompt) 5 (Extension, arbitrary constant) X (Hard limit)
         logger.debug(f"Extending session length {datetime.datetime.now()}")
         return self._get(f"{Settings.web_service_path}/STO_CHK", auth_header=True, params={"pExtend": sto})


### PR DESCRIPTION
Aiming to make logon.py slightly simpler to aid testing. 

Only (breaking) functionality change is that when the user has multiple roles with the same name, the first is now chosen instead of the last.