### PR TITLE
✨ ci.Logon accepts a role location argument!

### DIFF
--- a/compass/__init__.py
+++ b/compass/__init__.py
@@ -29,9 +29,9 @@ __all__ = (
 )
 
 
-def login(username: str, password: str, compass_role: Optional[str] = None) -> Logon:
+def login(username: str, password: str, /, *, role: Optional[str] = None, location: Optional[str] = None) -> Logon:
     """Log in to compass, return a compass.logon.Logon object.
 
     This function is provided as a convenient interface to the logon module.
     """
-    return Logon((username, password), compass_role)
+    return Logon((username, password), role, location)

--- a/compass/core/logon.py
+++ b/compass/core/logon.py
@@ -51,7 +51,7 @@ class Logon(InterfaceBase):
         self._member_role_number = 0
         self.compass_dict: dict[str, Union[int, str]] = {}
 
-        self.current_role: tuple[str, str] = "", ""
+        self.current_role: tuple[str, str] = ("", "")
         self.roles_dict: dict[int, str] = {}
 
         # Create session


### PR DESCRIPTION
Allow changing role with multiple identical role names with optional `location` parameter.

Breaking change as `ci.login` now enforces positional and keyword only arguments

cc: @arbitrarypunter for information.