### PR TITLE
⚗ namespaces trickery

### DIFF
--- a/compass/__init__.py
+++ b/compass/__init__.py
@@ -14,6 +14,10 @@ from compass.core.logon import Logon
 from compass.core.people import People
 from compass.core.reports import Reports
 
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # NoQA
+# https://stackoverflow.com/a/53486554
+# We want to expose names on the global namespace, but also use namespace packages.
+
 __all__ = (
     # sub-packages: CI-Core
     "core",

--- a/compass/__init__.py
+++ b/compass/__init__.py
@@ -2,17 +2,19 @@
 
 This module exposes the public api for CI core
 """
+from __future__ import annotations
 
-# This directory is a Python package.
-from typing import Optional
+from typing import TYPE_CHECKING
 
-from compass import core
 from compass.core import errors
 from compass.core import logger
 from compass.core.hierarchy import Hierarchy
 from compass.core.logon import Logon
 from compass.core.people import People
 from compass.core.reports import Reports
+
+if TYPE_CHECKING:
+    from typing import Optional
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)  # NoQA
 # https://stackoverflow.com/a/53486554
@@ -31,6 +33,15 @@ __all__ = (
     # public functions
     "login",
 )
+
+# Further abuse of the import system - here we register other subpackages if they exist
+for m in ("api", "util", "interface"):
+    try:
+        __import__(f"compass.{m}")
+        __all__ += (m,)
+    except ModuleNotFoundError:
+        pass
+del m
 
 
 def login(username: str, password: str, /, *, role: Optional[str] = None, location: Optional[str] = None) -> Logon:

--- a/compass/core/__init__.py
+++ b/compass/core/__init__.py
@@ -2,9 +2,7 @@
 
 This module exposes the public api for CI core
 """
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
+from typing import Optional
 
 from compass.core import errors
 from compass.core import logger
@@ -13,16 +11,8 @@ from compass.core.logon import Logon
 from compass.core.people import People
 from compass.core.reports import Reports
 
-if TYPE_CHECKING:
-    from typing import Optional
-
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # NoQA
-# https://stackoverflow.com/a/53486554
-# We want to expose names on the global namespace, but also use namespace packages.
-
 __all__ = (
     # sub-packages: CI-Core
-    "core",
     "errors",
     "logger",
     # public classes
@@ -33,15 +23,6 @@ __all__ = (
     # public functions
     "login",
 )
-
-# Further abuse of the import system - here we register other subpackages if they exist
-for m in ("api", "util", "interface"):
-    try:
-        __import__(f"compass.{m}")
-        __all__ += (m,)
-    except ModuleNotFoundError:
-        pass
-del m
 
 
 def login(username: str, password: str, /, *, role: Optional[str] = None, location: Optional[str] = None) -> Logon:

--- a/compass/core/__init__.py
+++ b/compass/core/__init__.py
@@ -2,11 +2,10 @@
 
 This module exposes the public api for CI core
 """
-from typing import Optional
-
 from compass.core import errors
 from compass.core import logger
 from compass.core.hierarchy import Hierarchy
+from compass.core.logon import login
 from compass.core.logon import Logon
 from compass.core.people import People
 from compass.core.reports import Reports
@@ -23,11 +22,3 @@ __all__ = (
     # public functions
     "login",
 )
-
-
-def login(username: str, password: str, /, *, role: Optional[str] = None, location: Optional[str] = None) -> Logon:
-    """Log in to compass, return a compass.logon.Logon object.
-
-    This function is provided as a convenient interface to the logon module.
-    """
-    return Logon((username, password), role, location)

--- a/compass/core/logon.py
+++ b/compass/core/logon.py
@@ -24,6 +24,14 @@ TYPES_UNIT_LEVELS = Literal["Group", "District", "County", "Region", "Country", 
 TYPES_STO = Literal[None, "0", "5", "X"]
 
 
+def login(username: str, password: str, /, *, role: Optional[str] = None, location: Optional[str] = None) -> Logon:
+    """Log in to compass, return a compass.logon.Logon object.
+
+    This function is provided as a convenient interface to the logon module.
+    """
+    return Logon((username, password), role, location)
+
+
 class Logon(InterfaceBase):
     """Create connection to Compass and authenticate. Holds session state.
 


### PR DESCRIPTION
All this is incredibly arcane and slightly dodgy.

To maintain some backwards compat, we want to expose `ci.People`, `ci.Reports`, `ci.login` etc, whilst allowing namespace packages in other projects. 

The simple solution would be to do away with `__init__.py` (https://github.com/the-scouts/compass-interface-core/blob/master/compass/__init__.py), but this would mean import are (subjectivley) less clean:

Azure SDK style (https://github.com/Azure/azure-sdk-for-python/tree/master/sdk)
- `from compass.core.people import People`
- `from compass import util`

Blended style:
- `import compass.core as ci`
- `ci.blah` as in CI core already
- `from compass import util`

I will probably suggest moving towards the second, as it means we don't need this alchemy -- but can be persuaded.