### PR TITLE
🥅 Add validation errors bypass

### DIFF
--- a/compass/core/settings.py
+++ b/compass/core/settings.py
@@ -10,6 +10,7 @@ class _SettingsModel(pydantic.BaseSettings):
     wcf_json_endpoint: str = "/JSon.svc"  # Windows communication foundation JSON service endpoint
     web_service_path: pydantic.HttpUrl = base_url + wcf_json_endpoint  # type: ignore[assignment]
     debug: bool = False
+    validation_errors: bool = True
 
     class Config:  # noqa: D106
         case_sensitive = False  # this is the default, but mark for clarity.

--- a/compass/core/utility.py
+++ b/compass/core/utility.py
@@ -10,6 +10,7 @@ from typing import Any, Optional, TYPE_CHECKING
 import pydantic
 
 from compass.core.logger import logger
+from compass.core.settings import Settings
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -63,8 +64,9 @@ def validation_errors_logging(id_value: int, name: str = "Member No") -> Iterato
     try:
         yield
     except pydantic.ValidationError as err:
-        logger.error(f"Parsing Error! {name}: {id_value}")
-        raise err
+        logger.exception(f"Parsing Error! {name}: {id_value}")
+        if Settings.validation_errors is True:
+            raise err
 
 
 class PeriodicTimer:


### PR DESCRIPTION
Currently all validation failures cause failing exceptions. Add a setting to bypass validation failures.