### PR TITLE
Added Missing adult awards  (gallantry/meritorious) to Member schema

### DIFF
--- a/compass/core/schemas/member.py
+++ b/compass/core/schemas/member.py
@@ -198,6 +198,16 @@ TYPES_AWARD_TYPE = Literal[
     # ???
     "Medal of Merit",
     "Bar to the Medal of Merit",
+    # Meritorious Conduct Awards
+    "Chief Scout's Commendation for Meritorious Conduct",
+    "The Medal for Meritorious Conduct",
+    # Gallantry Awards
+    "The Gilt Cross",
+    "The Silver Cross",
+    "The Bronze Cross",
+    # Other Awards
+    "The Cornwell Scout Badge",
+    "The Chief Scout's Personal Award",
 ]
 TYPES_DISCLOSURE_PROVIDERS = Literal[
     "Access NI",

--- a/compass/core/schemas/member.py
+++ b/compass/core/schemas/member.py
@@ -195,9 +195,6 @@ TYPES_AWARD_TYPE = Literal[
     # Formal awards process - higher good service
     "Bar to the Silver Acorn",
     "Silver Wolf",
-    # ???
-    "Medal of Merit",
-    "Bar to the Medal of Merit",
     # Meritorious Conduct Awards
     "Chief Scout's Commendation for Meritorious Conduct",
     "The Medal for Meritorious Conduct",
@@ -208,6 +205,9 @@ TYPES_AWARD_TYPE = Literal[
     # Other Awards
     "The Cornwell Scout Badge",
     "The Chief Scout's Personal Award",
+    # non-current/past/defunct/etc awards
+    "Medal of Merit",
+    "Bar to the Medal of Merit",
 ]
 TYPES_DISCLOSURE_PROVIDERS = Literal[
     "Access NI",

--- a/compass/core/schemas/member.py
+++ b/compass/core/schemas/member.py
@@ -205,7 +205,7 @@ TYPES_AWARD_TYPE = Literal[
     # Other Awards
     "The Cornwell Scout Badge",
     "The Chief Scout's Personal Award",
-    # non-current/past/defunct/etc awards
+    # Past Awards (not in the current awards scheme)
     "Medal of Merit",
     "Bar to the Medal of Merit",
 ]


### PR DESCRIPTION
Adam
Was checking to see if any new awards had appeared for my members and the script bailed with an unexpected value for MemberAward. Ive updated the schema with those that are liseted here: https://www.scouts.org.uk/volunteers/learning-development-and-awards/awards-and-recognition/meritorious-conduct-and-gallantry-awards/
I can't actually test any of them except "Chief Scout's Commendation for Meritorious Conduct" - but it should work....
